### PR TITLE
Potential fix for code scanning alert no. 184: Code injection

### DIFF
--- a/.github/workflows/cleanup-report.yml
+++ b/.github/workflows/cleanup-report.yml
@@ -26,6 +26,7 @@ jobs:
       - name: Cleanup HTML reports on PR close/merge
         env:
           BRANCH_REPORTS_DIR: reports/${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           if [ -d "$BRANCH_REPORTS_DIR" ]; then
             rm -rf "$BRANCH_REPORTS_DIR"
@@ -33,5 +34,5 @@ jobs:
             git commit -m "workflow: remove all reports for branch ${{ github.event.pull_request.head.ref }} (PR closed/merged)"
             git push
           else
-            echo "No reports found for branch ${{ github.event.pull_request.head.ref }}. Nothing to clean up."
+            echo "No reports found for branch \"$PR_HEAD_REF\". Nothing to clean up."
           fi


### PR DESCRIPTION
Potential fix for [https://github.com/guruh46/cal.com/security/code-scanning/184](https://github.com/guruh46/cal.com/security/code-scanning/184)

**In general terms:**  
To fix potential shell injection vulnerabilities, do not interpolate untrusted expressions directly into shell commands. Instead, assign untrusted values to environment variables via the `env:` block and use shell parameter expansion to reference them within the script. This ensures proper escaping and prevents code injection.

**Specifics for this fix:**  
- For line 36, instead of `echo "No reports found for branch ${{ github.event.pull_request.head.ref }}. Nothing to clean up."`, set the value of `${{ github.event.pull_request.head.ref }}` to an environment variable (e.g., `PR_HEAD_REF`) in the `env:` block of the current step.
- Then, in the shell script, use `"$PR_HEAD_REF"` instead of `${{ github.event.pull_request.head.ref }}`.  
- Update the `env:` block (line 28) to add this variable.
- Update the `echo` command (line 36) to use the env variable.

**What is needed:**  
- Edit the step at lines 26–37:
  - Expand the `env:` block to add `PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}`.
  - Change the shell code at line 36 to use `"$PR_HEAD_REF"` instead of the expression.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
